### PR TITLE
Fix img4tool class

### DIFF
--- a/Formula/img4tool.rb
+++ b/Formula/img4tool.rb
@@ -1,4 +1,4 @@
-class Img4toolTihmstar < Formula
+class Img4tool < Formula
   desc "Tool for manipulating IMG4, IM4M and IM4P files"
   homepage "https://github.com/tihmstar/img4tool"
   url "https://github.com/tihmstar/img4tool.git",


### PR DESCRIPTION
This was resulting in [this error message](https://pastebin.com/swM6PRAN) when trying to install the tap. Tested the change on my fork, and it works!