### PR TITLE
Add libtatsu formula

### DIFF
--- a/Formula/idevicerestore.rb
+++ b/Formula/idevicerestore.rb
@@ -25,6 +25,7 @@ class Idevicerestore < Formula
   depends_on "pkg-config" => :build
 
   depends_on "libplist"
+  depends_on "libtatsu"
   depends_on "libzip"
   depends_on "stek29/idevice/libimobiledevice"
   depends_on "stek29/idevice/libirecovery"

--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -28,6 +28,7 @@ class Libimobiledevice < Formula
   depends_on "libimobiledevice-glue"
   depends_on "libplist"
   depends_on "libtasn1"
+  depends_on "libtatsu"
   depends_on "openssl@3"
   depends_on "stek29/idevice/libusbmuxd"
 

--- a/Formula/libtatsu.rb
+++ b/Formula/libtatsu.rb
@@ -1,0 +1,41 @@
+class Libtatsu < Formula
+  desc "Library handling the communication with Apple's Tatsu Signing Server (TSS)"
+  homepage "https://github.com/libimobiledevice/libtatsu"
+  url "https://github.com/libimobiledevice/libtatsu.git",
+    revision: "e3eb2e224781f6522e2cf63c35c2c249747d648d"
+  version "1.0.3"
+  license "LGPL-2.1-or-later"
+  head "https://github.com/libimobiledevice/libtatsu.git", branch: "master"
+
+  livecheck do
+    skip "upstream has inconsistent tags"
+  end
+
+  # bottle do
+  #   root_url "https://github.com/stek29/homebrew-idevice/releases/download/libirecovery-1.1.0-25-g447ae09"
+  #   sha256 cellar: :any, arm64_sonoma: "3a3b9c1c585ab8fd269768d317559d486c0f0fb34fc94e885f4ee4a55f51f038"
+  #   sha256 cellar: :any, ventura:      "839aa7ff745790403e66f3ac5d114480d07d9ae25b4c6bead9bfc8571de9e82c"
+  # end
+
+  keg_only "it can conflict with homebrew/core"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "libplist"
+
+  def install
+    args = %w[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+    ]
+
+    system "./autogen.sh", *std_configure_args, *args
+
+    system "make"
+    system "make", "install"
+  end
+end

--- a/Formula/libtatsu.rb
+++ b/Formula/libtatsu.rb
@@ -1,21 +1,14 @@
 class Libtatsu < Formula
   desc "Library handling the communication with Apple's Tatsu Signing Server (TSS)"
   homepage "https://github.com/libimobiledevice/libtatsu"
-  url "https://github.com/libimobiledevice/libtatsu.git",
-    revision: "e3eb2e224781f6522e2cf63c35c2c249747d648d"
-  version "1.0.3"
+  url "https://github.com/libimobiledevice/libtatsu/releases/download/1.0.4/libtatsu-1.0.4.tar.bz2"
+  sha256 "08094e58364858360e1743648581d9bad055ba3b06e398c660e481ebe0ae20b3"
   license "LGPL-2.1-or-later"
   head "https://github.com/libimobiledevice/libtatsu.git", branch: "master"
 
   livecheck do
     skip "upstream has inconsistent tags"
   end
-
-  # bottle do
-  #   root_url "https://github.com/stek29/homebrew-idevice/releases/download/libirecovery-1.1.0-25-g447ae09"
-  #   sha256 cellar: :any, arm64_sonoma: "3a3b9c1c585ab8fd269768d317559d486c0f0fb34fc94e885f4ee4a55f51f038"
-  #   sha256 cellar: :any, ventura:      "839aa7ff745790403e66f3ac5d114480d07d9ae25b4c6bead9bfc8571de9e82c"
-  # end
 
   keg_only "it can conflict with homebrew/core"
 
@@ -33,7 +26,7 @@ class Libtatsu < Formula
       --disable-silent-rules
     ]
 
-    system "./autogen.sh", *std_configure_args, *args
+    system "./configure", *std_configure_args, *args
 
     system "make"
     system "make", "install"


### PR DESCRIPTION
`idevicerestore` and `libimobiledevice` have a new compile time dependency: [`libtatsu`](https://github.com/libimobiledevice/libtatsu).  
This PR adds a formula for it and adjusts the dependencies of other formulae appropriately.