### PR TITLE
Fix Homebrew runtime error on macOS

### DIFF
--- a/Formula/img4lib.rb
+++ b/Formula/img4lib.rb
@@ -41,7 +41,7 @@ class Img4lib < Formula
         # remove libcompression check – it's expected to be present on recent macOS versions
         inreplace "Makefile",
           "$(wildcard /usr/lib/libcompression.dylib)", "x",
-          false
+          audit_result: false
       end
     end
 


### PR DESCRIPTION
Homebrew complains that only 3 positional arguments are allowed to the `inreplace` command. This explicitly names the fourth parameter to resolve the issue.